### PR TITLE
Support installing the balena CLI from a release channel

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -17,9 +17,12 @@ runs:
   steps:
     - name: Test setup of balena CLI
       uses: ./
+      env:
+        # renovate: datasource=github-releases depName=balena-io/balena-cli
+        BALENA_CLI_VERSION: v23.2.32
       with:
         balena-token: ${{ fromJSON(inputs.secrets).BALENA_API_KEY }}
-        cli-version: ${{ env.matrix_value }}
+        cli-version: ${{ env.matrix_value == 'pinned' && env.BALENA_CLI_VERSION || env.matrix_value }}
     - name: Print balena CLI version
       shell: bash
       run: |

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -22,7 +22,9 @@ runs:
         BALENA_CLI_VERSION: v23.2.32
       with:
         balena-token: ${{ fromJSON(inputs.secrets).BALENA_API_KEY }}
-        cli-version: ${{ env.matrix_value == 'pinned' && env.BALENA_CLI_VERSION || env.matrix_value }}
+        # cli-version cannot be unset, so the channel case leaves it at the default
+        cli-version: ${{ (env.matrix_value == 'pinned' && env.BALENA_CLI_VERSION) || (env.matrix_value == 'channel' && 'latest') || env.matrix_value }}
+        cli-channel: ${{ env.matrix_value == 'channel' && 'stable' || '' }}
     - name: Print balena CLI version
       shell: bash
       run: |

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -27,6 +27,7 @@ jobs:
       custom_test_matrix: >
         {
           value: [
+            "pinned",
             "latest"
           ],
           os: ["ubuntu-latest", "windows-latest", "macos-latest"]

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -27,8 +27,6 @@ jobs:
       custom_test_matrix: >
         {
           value: [
-            "v21.1.14",
-            "v22.0.0",
             "latest"
           ],
           os: ["ubuntu-latest", "windows-latest", "macos-latest"]

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -28,7 +28,8 @@ jobs:
         {
           value: [
             "pinned",
-            "latest"
+            "latest",
+            "channel"
           ],
           os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ with:
   # Default: 'latest'
   cli-version: ''
 
+  # balena CLI release channel to install (example: `my-feature-branch`)
+  # Mutually exclusive with `cli-version`
+  # Default: ''
+  cli-channel: ''
+
   # balenaCloud API token to login automatically
   # Default: ''
   balena-token: ''
@@ -38,6 +43,23 @@ with:
   with:
     cli-version: v18.1.9
 ```
+
+### Install from a release channel
+
+Every balena CLI pull request publishes a build to a release channel named after
+its branch, and finished releases are published to the `stable` channel. This is
+the same mechanism `balena update <channel>` uses to switch an existing install.
+
+```yaml
+- name: Setup balena CLI
+  uses: balena-io-examples/setup-balena-action@main
+  with:
+    cli-channel: my-feature-branch
+```
+
+A branch channel contains unreviewed code, and its contents change as the pull
+request gains commits. Use it to test an unreleased fix, not in a workflow that
+holds a production `balena-token`.
 
 ### Login to balenaCloud
 

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: "balena CLI version to install (example: `v18.1.9`)"
     required: false
     default: latest
+  cli-channel:
+    description: "balena CLI release channel to install (example: `my-feature-branch`)"
+    required: false
   balena-token:
     description: "balenaCloud API token to login automatically"
     required: false
@@ -19,8 +22,16 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Check inputs
+      if: inputs.cli-channel != '' && inputs.cli-version != '' && inputs.cli-version != 'latest'
+      shell: bash
+      working-directory: ${{ runner.temp }}
+      run: |
+        echo "::error::Inputs cli-version and cli-channel are mutually exclusive"
+        exit 1
+
     - name: Use latest release
-      if: inputs.cli-version == 'latest' || inputs.cli-version == ''
+      if: inputs.cli-channel == '' && (inputs.cli-version == 'latest' || inputs.cli-version == '')
       id: latest
       shell: bash
       working-directory: ${{ runner.temp }}
@@ -30,29 +41,21 @@ runs:
       run: |
         echo "release=${BALENA_CLI_VERSION}" >> "${GITHUB_OUTPUT}"
 
-    - name: Restore tool cache
-      if: inputs.skip-cache != 'true'
-      id: cache
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-      with:
-        path: ${{ runner.tool_cache }}/balena
-        key: balena-cli-${{ runner.os }}-${{ runner.arch }}-${{ steps.latest.outputs.release || inputs.cli-version }}
-
+    # Runs unconditionally, as resolving a channel needs the platform triple
+    # before there is a cache key to restore with
     - name: Get runner os
-      if: steps.cache.outputs.cache-hit != 'true'
       id: os
       shell: bash
       working-directory: ${{ runner.temp }}
       run: |
         case "${{ runner.os }}" in
-          Linux) echo "target=linux" >> "${GITHUB_OUTPUT}" ;;
-          macOS) echo "target=macOS" >> "${GITHUB_OUTPUT}" ;;
-          Windows) echo "target=windows" >> "${GITHUB_OUTPUT}" ;;
+          Linux) echo "target=linux" >> "${GITHUB_OUTPUT}" ; echo "platform=linux" >> "${GITHUB_OUTPUT}" ;;
+          macOS) echo "target=macOS" >> "${GITHUB_OUTPUT}" ; echo "platform=darwin" >> "${GITHUB_OUTPUT}" ;;
+          Windows) echo "target=windows" >> "${GITHUB_OUTPUT}" ; echo "platform=win32" >> "${GITHUB_OUTPUT}" ;;
           *) echo "::error::Unsupported os: ${{ runner.os }}" ; exit 1 ;;
         esac
 
     - name: Get runner arch
-      if: steps.cache.outputs.cache-hit != 'true'
       id: arch
       shell: bash
       working-directory: ${{ runner.temp }}
@@ -63,8 +66,62 @@ runs:
           *) echo "::error::Unsupported arch: ${{ runner.arch }}" ; exit 1 ;;
         esac
 
+    - name: Resolve release channel
+      if: inputs.cli-channel != ''
+      id: channel
+      shell: bash --noprofile --norc -eo pipefail {0}
+      working-directory: ${{ runner.temp }}
+      env:
+        # balena-io/balena-cli: package.json oclif.update.s3.host
+        S3_HOST: https://balena-cli.s3.us-east-1.amazonaws.com
+        CHANNEL: ${{ inputs.cli-channel }}
+        PLATFORM: ${{ steps.os.outputs.platform }}
+        ARCH: ${{ steps.arch.outputs.target }}
+      run: |
+        URL="${S3_HOST}/channels/${CHANNEL}/balena-${PLATFORM}-${ARCH}-buildmanifest"
+        # The bucket denies s3:ListBucket, so a missing key returns 403 not 404
+        if ! MANIFEST="$(curl -fsSL "${URL}")"; then
+          echo "::error::No balena CLI build for channel '${CHANNEL}' on ${PLATFORM}-${ARCH} (${URL})"
+          exit 1
+        fi
+        GZ="$(echo "${MANIFEST}" | jq -er '.gz')"
+        SHA256="$(echo "${MANIFEST}" | jq -er '.sha256gz')"
+        VERSION="$(echo "${MANIFEST}" | jq -er '.version')"
+        SHA="$(echo "${MANIFEST}" | jq -er '.sha')"
+        {
+          echo "gz=${GZ}"
+          echo "sha256=${SHA256}"
+          echo "cache-key=${CHANNEL}-${VERSION}-${SHA}"
+        } >> "${GITHUB_OUTPUT}"
+
+    - name: Restore tool cache
+      if: inputs.skip-cache != 'true'
+      id: cache
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ${{ runner.tool_cache }}/balena
+        key: balena-cli-${{ runner.os }}-${{ runner.arch }}-${{ steps.channel.outputs.cache-key || steps.latest.outputs.release || inputs.cli-version }}
+
+    - name: Download balena CLI from release channel
+      if: steps.cache.outputs.cache-hit != 'true' && inputs.cli-channel != ''
+      working-directory: ${{ runner.tool_cache }}
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      env:
+        GZ: ${{ steps.channel.outputs.gz }}
+        SHA256: ${{ steps.channel.outputs.sha256 }}
+      run: |
+        curl -fsSL "${GZ}" -o balena-cli.tar.gz
+        # macOS ships shasum only, Ubuntu and Git for Windows ship both
+        if command -v sha256sum >/dev/null 2>&1; then
+          echo "${SHA256}  balena-cli.tar.gz" | sha256sum -c -
+        else
+          echo "${SHA256}  balena-cli.tar.gz" | shasum -a 256 -c -
+        fi
+        tar -xzf balena-cli.tar.gz
+        rm -vf balena-cli.tar.gz
+
     - name: Download balena CLI
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true' && inputs.cli-channel == ''
       working-directory: ${{ runner.tool_cache }}
       shell: bash --noprofile --norc -eo pipefail -x {0}
       env:


### PR DESCRIPTION
balena CLI pull requests publish oclif builds to an S3 release channel named
after the branch, and finished releases go to the `stable` channel. Add a
`cli-channel` input that resolves the channel buildmanifest and installs the
tarball it points at, so a workflow can test an unreleased CLI build.

The channel path verifies the manifest `sha256gz` before extracting, and its
cache key includes the resolved version and commit because a channel moves as
its pull request gains commits.

See: https://balena.fibery.io/Work/Improvement/Support-release-channels-in-setup-balena-action-4651